### PR TITLE
solve a bug where (0,0) is a valid signature for any message

### DIFF
--- a/contracts/Secp256r1.sol
+++ b/contracts/Secp256r1.sol
@@ -24,7 +24,7 @@ contract Secp256r1 {
     function Verify(uint X, uint Y, uint r, uint s, bytes memory input)
         public pure returns (bool)
     {
-        if (r >= nn || s >= nn) {
+        if (r==0 || s==0 ||r >= nn || s >= nn) {
             return false;
         }
 


### PR DESCRIPTION
test r and s value not zeroes